### PR TITLE
fix for 2 letter paramaters

### DIFF
--- a/LSF/JobManager.pm
+++ b/LSF/JobManager.pm
@@ -113,7 +113,7 @@ sub parse_flags{
     my @defaults = @_;
     my %hash;
     while(local $_ = shift @defaults){
-        if(/^(-\w)(.*)/){
+        if(/^(-\w+)(.*)/){
             my($flag,$value) = ($1,$2);
             if($value ne ''){
                 $hash{$flag} = $value;


### PR DESCRIPTION
fix for 2 letter paramaters
e.g. -eo (error overwrite)
